### PR TITLE
Fix gl error by checking nodeposition data in advance

### DIFF
--- a/src/controllers/vda5050-agv.controller.ts
+++ b/src/controllers/vda5050-agv.controller.ts
@@ -167,8 +167,8 @@ export class VDA5050Agv {
       }
       this.layouts.value!.nodes[node.nodeId] = {
         fixed: true,
-        x: node.nodePosition!.x,
-        y: -node.nodePosition!.y,
+        x: node.nodePosition ? node.nodePosition.x : 0,
+        y: node.nodePosition ? -node.nodePosition.y : 0,
       };
     });
     order.edges.map((edge: Edge) => {


### PR DESCRIPTION
Current main branch occur error in GL as following

<img width="1700" alt="스크린샷 2024-09-10 오후 4 11 35" src="https://github.com/user-attachments/assets/90f755fa-cc87-4877-a2f0-a7bddc2fc30f">

This error fixed by checking nodePosition data before get data from this instance

<img width="1700" alt="스크린샷 2024-09-10 오후 4 12 02" src="https://github.com/user-attachments/assets/3d2c60f6-d15c-4734-b93b-50722bec57b1">
