### PR TITLE
add json create order

### DIFF
--- a/src/components/InstantActionPublisher.vue
+++ b/src/components/InstantActionPublisher.vue
@@ -5,8 +5,21 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Icon } from "@iconify/vue";
 import { useToast } from "@/components/ui/toast";
+import {
+  formatInstantActionsJson,
+  instantActionsToFormState,
+  parseInstantActionsJson,
+  splitInstantActionJsonDocuments,
+} from "@/utils/instant-action-json";
 import type { InstantActions, Action } from "vda-5050-lib";
 import { BlockingType as BlockingTypeEnum } from "@/types/vda5050.types";
 
@@ -127,6 +140,13 @@ const { agvControllers, interfaceName } = useVDA5050();
 const { toast } = useToast();
 
 const error = ref("");
+const jsonHint = ref("");
+const showJsonImport = ref(false);
+const instantActionsJsonText = ref("");
+const jsonDocumentCount = ref(1);
+const jsonDocuments = ref<string[]>([]);
+const selectedJsonDocumentIndex = ref(0);
+const jsonFileInputRef = ref<HTMLInputElement | null>(null);
 const expandedSections = ref<Set<string>>(new Set(["instantAction-basic"]));
 
 // InstantActions form state
@@ -174,6 +194,179 @@ const buildInstantActionsFromForm = (): InstantActions => {
     version: instantActionsForm.value.version,
     instantActions: instantActionsForm.value.instantActions,
   };
+};
+
+const applyJsonToForm = () => {
+  try {
+    const docs =
+      jsonDocuments.value.length > 0
+        ? jsonDocuments.value
+        : splitInstantActionJsonDocuments(instantActionsJsonText.value);
+    if (docs.length === 0) {
+      error.value = "JSON is empty.";
+      return;
+    }
+
+    const index = Math.min(selectedJsonDocumentIndex.value, docs.length - 1);
+    const { instantActions, warnings } = parseInstantActionsJson(
+      docs[index],
+      props.agvId
+    );
+    instantActionsForm.value = instantActionsToFormState(
+      instantActions,
+      props.agvId
+    );
+    instantActionsJsonText.value = formatInstantActionsJson(instantActions);
+    jsonDocuments.value = docs;
+    jsonDocumentCount.value = docs.length;
+    selectedJsonDocumentIndex.value = index;
+    error.value = "";
+    jsonHint.value = warnings.join(" ");
+
+    expandedSections.value = new Set([
+      "instantAction-basic",
+      "instantAction-actions",
+    ]);
+
+    const actionCount = instantActions.instantActions?.length ?? 0;
+    toast({
+      title: "JSON applied",
+      description:
+        warnings.length > 0
+          ? `Loaded ${actionCount} action(s) (${warnings.length} warning(s)). Review and edit below.`
+          : `Loaded ${actionCount} action(s) into the form. You can review and edit below.`,
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    error.value = message;
+    jsonHint.value = "";
+  }
+};
+
+const validateInstantActionsJson = () => {
+  try {
+    const docs = splitInstantActionJsonDocuments(instantActionsJsonText.value);
+    if (docs.length === 0) {
+      error.value = "JSON is empty.";
+      jsonHint.value = "";
+      return;
+    }
+
+    jsonDocuments.value = docs;
+    const parsed = docs.map((doc) => parseInstantActionsJson(doc, props.agvId));
+    jsonDocumentCount.value = docs.length;
+    selectedJsonDocumentIndex.value = Math.min(
+      selectedJsonDocumentIndex.value,
+      docs.length - 1
+    );
+
+    const { instantActions, warnings } =
+      parsed[selectedJsonDocumentIndex.value];
+    const actionCount = instantActions.instantActions?.length ?? 0;
+    error.value = "";
+    jsonHint.value = [
+      `Valid VDA5050 instantActions (${actionCount} action${actionCount === 1 ? "" : "s"}).`,
+      docs.length > 1 ? `${docs.length} documents found in editor.` : "",
+      ...warnings,
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    toast({
+      title: "JSON valid",
+      description: `InstantActions message is valid. Click "Apply to form" to load it.`,
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    error.value = message;
+    jsonHint.value = "";
+  }
+};
+
+const formatInstantActionsJsonEditor = () => {
+  try {
+    const docs = splitInstantActionJsonDocuments(instantActionsJsonText.value);
+    if (docs.length === 0) {
+      error.value = "JSON is empty.";
+      return;
+    }
+
+    const index = Math.min(selectedJsonDocumentIndex.value, docs.length - 1);
+    const { instantActions } = parseInstantActionsJson(docs[index], props.agvId);
+    instantActionsJsonText.value = formatInstantActionsJson(instantActions);
+    error.value = "";
+    jsonHint.value = "JSON formatted.";
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    error.value = message;
+  }
+};
+
+const loadJsonFromFile = () => {
+  jsonFileInputRef.value?.click();
+};
+
+const onJsonFileSelected = async (event: Event) => {
+  const input = event.target as HTMLInputElement;
+  const file = input.files?.[0];
+  input.value = "";
+
+  if (!file) return;
+
+  try {
+    const text = await file.text();
+    const docs = splitInstantActionJsonDocuments(text);
+    jsonDocuments.value = docs;
+    jsonDocumentCount.value = docs.length;
+    selectedJsonDocumentIndex.value = 0;
+    instantActionsJsonText.value = text;
+
+    if (docs.length === 1) {
+      const { instantActions, warnings } = parseInstantActionsJson(
+        docs[0],
+        props.agvId
+      );
+      instantActionsJsonText.value = formatInstantActionsJson(instantActions);
+      jsonHint.value = warnings.join(" ");
+    } else {
+      jsonHint.value = `Loaded ${docs.length} documents from ${file.name}. Select one and click "Apply to form".`;
+    }
+
+    showJsonImport.value = true;
+    error.value = "";
+
+    toast({
+      title: "File loaded",
+      description: `${file.name} (${docs.length} document${docs.length > 1 ? "s" : ""})`,
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    error.value = `Failed to read file: ${message}`;
+  }
+};
+
+const selectJsonDocumentByIndex = (index: number) => {
+  selectedJsonDocumentIndex.value = index;
+  const docs =
+    jsonDocuments.value.length > 0
+      ? jsonDocuments.value
+      : splitInstantActionJsonDocuments(instantActionsJsonText.value);
+
+  if (!docs[index]) return;
+
+  try {
+    const { instantActions } = parseInstantActionsJson(docs[index], props.agvId);
+    instantActionsJsonText.value = formatInstantActionsJson(instantActions);
+    const actionCount = instantActions.instantActions?.length ?? 0;
+    jsonHint.value = `Showing document ${index + 1} of ${docs.length} (${actionCount} action${actionCount === 1 ? "" : "s"}).`;
+  } catch {
+    instantActionsJsonText.value = docs[index];
+    jsonHint.value = `Showing raw document ${index + 1} of ${docs.length}.`;
+  }
+};
+
+const toggleJsonImport = () => {
+  showJsonImport.value = !showJsonImport.value;
 };
 
 // Publish InstantActions
@@ -277,14 +470,25 @@ const getActionDescription = (
         <Icon icon="material-symbols:flash-on" class="w-4 h-4" />
         Create Instant Action
       </div>
-      <Button
-        variant="ghost"
-        size="sm"
-        class="h-6 w-6 p-0"
-        @click="emit('close')"
-      >
-        <Icon icon="material-symbols:close" class="w-4 h-4" />
-      </Button>
+      <div class="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          class="h-7 text-xs"
+          @click="toggleJsonImport"
+        >
+          <Icon icon="material-symbols:data-object" class="w-3.5 h-3.5 mr-1" />
+          {{ showJsonImport ? "Hide JSON" : "Import JSON" }}
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          class="h-6 w-6 p-0"
+          @click="emit('close')"
+        >
+          <Icon icon="material-symbols:close" class="w-4 h-4" />
+        </Button>
+      </div>
     </div>
 
     <div
@@ -292,6 +496,104 @@ const getActionDescription = (
       class="text-sm text-red-500 bg-red-50 dark:bg-red-950 p-2 rounded"
     >
       {{ error }}
+    </div>
+
+    <div
+      v-if="jsonHint && !error"
+      class="text-sm text-muted-foreground bg-muted/50 p-2 rounded"
+    >
+      {{ jsonHint }}
+    </div>
+
+    <input
+      ref="jsonFileInputRef"
+      type="file"
+      accept=".json,.txt,application/json,text/plain"
+      class="hidden"
+      @change="onJsonFileSelected"
+    />
+
+    <div
+      v-if="showJsonImport"
+      class="border rounded-lg p-4 space-y-3 bg-muted/20"
+    >
+      <div class="flex items-center justify-between mb-1">
+        <h3 class="font-semibold text-sm">Import from JSON</h3>
+        <span class="text-xs text-muted-foreground">
+          Apply loads data into the form below
+        </span>
+      </div>
+
+      <div class="flex flex-wrap gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          class="h-7 text-xs"
+          @click="loadJsonFromFile"
+        >
+          <Icon icon="material-symbols:upload-file" class="w-3.5 h-3.5 mr-1" />
+          Load file
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          class="h-7 text-xs"
+          @click="validateInstantActionsJson"
+        >
+          <Icon
+            icon="material-symbols:check-circle-outline"
+            class="w-3.5 h-3.5 mr-1"
+          />
+          Validate
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          class="h-7 text-xs"
+          @click="formatInstantActionsJsonEditor"
+        >
+          <Icon icon="material-symbols:data-object" class="w-3.5 h-3.5 mr-1" />
+          Format
+        </Button>
+        <Button size="sm" class="h-7 text-xs" @click="applyJsonToForm">
+          <Icon icon="material-symbols:input" class="w-3.5 h-3.5 mr-1" />
+          Apply to form
+        </Button>
+      </div>
+
+      <div v-if="jsonDocumentCount > 1" class="flex items-center gap-2">
+        <Label class="text-xs shrink-0">Document in file</Label>
+        <Select
+          :model-value="String(selectedJsonDocumentIndex)"
+          @update:model-value="(v) => selectJsonDocumentByIndex(Number(v))"
+        >
+          <SelectTrigger class="h-8 text-xs flex-1">
+            <SelectValue placeholder="Select document" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem
+              v-for="i in jsonDocumentCount"
+              :key="i - 1"
+              :value="String(i - 1)"
+            >
+              Document {{ i }} / {{ jsonDocumentCount }}
+            </SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div>
+        <Label class="text-xs text-muted-foreground">
+          Paste VDA5050 instantActions JSON. Multiple documents separated by
+          lines of = are supported.
+        </Label>
+        <Textarea
+          v-model="instantActionsJsonText"
+          class="mt-2 font-mono text-xs min-h-[160px]"
+          spellcheck="false"
+          placeholder='{ "headerId": 1, "version": "2.0.0", "instantActions": [{ "actionId": "a1", "actionType": "stateRequest", "blockingType": "NONE" }] }'
+        />
+      </div>
     </div>
 
     <div class="space-y-4">

--- a/src/components/OrderPublisher.vue
+++ b/src/components/OrderPublisher.vue
@@ -5,9 +5,22 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Icon } from "@iconify/vue";
 import { useToast } from "@/components/ui/toast";
 import { generateManhattanRoute } from "@/utils/manhattan-route";
+import {
+  formatOrderJson,
+  orderToFormState,
+  parseOrderJson,
+  splitOrderJsonDocuments,
+} from "@/utils/order-json";
 import type { Order, Node, Edge, Action } from "vda-5050-lib";
 import { BlockingType as BlockingTypeEnum } from "@/types/vda5050.types";
 
@@ -128,6 +141,13 @@ const { agvControllers, interfaceName } = useVDA5050();
 const { toast } = useToast();
 
 const error = ref("");
+const jsonHint = ref("");
+const showJsonImport = ref(false);
+const orderJsonText = ref("");
+const jsonOrderCount = ref(1);
+const jsonDocuments = ref<string[]>([]);
+const selectedJsonOrderIndex = ref(0);
+const jsonFileInputRef = ref<HTMLInputElement | null>(null);
 const expandedSections = ref<Set<string>>(new Set(["order-basic"]));
 
 // Order form state
@@ -190,6 +210,167 @@ const buildOrderFromForm = (): Order => {
   }
 
   return order;
+};
+
+const applyJsonToForm = () => {
+  try {
+    const docs =
+      jsonDocuments.value.length > 0
+        ? jsonDocuments.value
+        : splitOrderJsonDocuments(orderJsonText.value);
+    if (docs.length === 0) {
+      error.value = "JSON is empty.";
+      return;
+    }
+
+    const index = Math.min(selectedJsonOrderIndex.value, docs.length - 1);
+    const { order, warnings } = parseOrderJson(docs[index], props.agvId);
+    orderForm.value = orderToFormState(order, props.agvId);
+    orderJsonText.value = formatOrderJson(order);
+    jsonDocuments.value = docs;
+    jsonOrderCount.value = docs.length;
+    selectedJsonOrderIndex.value = index;
+    error.value = "";
+    jsonHint.value = warnings.join(" ");
+
+    expandedSections.value = new Set([
+      "order-basic",
+      "order-nodes",
+      "order-edges",
+    ]);
+
+    toast({
+      title: "JSON applied",
+      description:
+        warnings.length > 0
+          ? `Loaded order "${order.orderId}" into the form (${warnings.length} warning(s)).`
+          : `Loaded order "${order.orderId}" into the form. You can review and edit below.`,
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    error.value = message;
+    jsonHint.value = "";
+  }
+};
+
+const validateOrderJson = () => {
+  try {
+    const docs = splitOrderJsonDocuments(orderJsonText.value);
+    if (docs.length === 0) {
+      error.value = "JSON is empty.";
+      jsonHint.value = "";
+      return;
+    }
+
+    jsonDocuments.value = docs;
+    const parsed = docs.map((doc) => parseOrderJson(doc, props.agvId));
+    jsonOrderCount.value = docs.length;
+    selectedJsonOrderIndex.value = Math.min(
+      selectedJsonOrderIndex.value,
+      docs.length - 1
+    );
+
+    const { order, warnings } = parsed[selectedJsonOrderIndex.value];
+    error.value = "";
+    jsonHint.value = [
+      `Valid VDA5050 order: ${order.orderId} (${order.nodes?.length ?? 0} nodes, ${order.edges?.length ?? 0} edges).`,
+      docs.length > 1 ? `${docs.length} orders found in editor.` : "",
+      ...warnings,
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    toast({
+      title: "JSON valid",
+      description: `Order "${order.orderId}" is valid. Click "Apply to form" to load it.`,
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    error.value = message;
+    jsonHint.value = "";
+  }
+};
+
+const formatOrderJsonEditor = () => {
+  try {
+    const docs = splitOrderJsonDocuments(orderJsonText.value);
+    if (docs.length === 0) {
+      error.value = "JSON is empty.";
+      return;
+    }
+
+    const index = Math.min(selectedJsonOrderIndex.value, docs.length - 1);
+    const { order } = parseOrderJson(docs[index], props.agvId);
+    orderJsonText.value = formatOrderJson(order);
+    error.value = "";
+    jsonHint.value = "JSON formatted.";
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    error.value = message;
+  }
+};
+
+const loadJsonFromFile = () => {
+  jsonFileInputRef.value?.click();
+};
+
+const onJsonFileSelected = async (event: Event) => {
+  const input = event.target as HTMLInputElement;
+  const file = input.files?.[0];
+  input.value = "";
+
+  if (!file) return;
+
+  try {
+    const text = await file.text();
+    const docs = splitOrderJsonDocuments(text);
+    jsonDocuments.value = docs;
+    jsonOrderCount.value = docs.length;
+    selectedJsonOrderIndex.value = 0;
+    orderJsonText.value = text;
+
+    if (docs.length === 1) {
+      const { order, warnings } = parseOrderJson(docs[0], props.agvId);
+      orderJsonText.value = formatOrderJson(order);
+      jsonHint.value = warnings.join(" ");
+    } else {
+      jsonHint.value = `Loaded ${docs.length} orders from ${file.name}. Select one and click "Apply to form".`;
+    }
+
+    showJsonImport.value = true;
+    error.value = "";
+
+    toast({
+      title: "File loaded",
+      description: `${file.name} (${docs.length} order${docs.length > 1 ? "s" : ""})`,
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    error.value = `Failed to read file: ${message}`;
+  }
+};
+
+const selectJsonOrderByIndex = (index: number) => {
+  selectedJsonOrderIndex.value = index;
+  const docs =
+    jsonDocuments.value.length > 0
+      ? jsonDocuments.value
+      : splitOrderJsonDocuments(orderJsonText.value);
+
+  if (!docs[index]) return;
+
+  try {
+    const { order } = parseOrderJson(docs[index], props.agvId);
+    orderJsonText.value = formatOrderJson(order);
+    jsonHint.value = `Showing order ${index + 1} of ${docs.length}: ${order.orderId}`;
+  } catch {
+    orderJsonText.value = docs[index];
+    jsonHint.value = `Showing raw document ${index + 1} of ${docs.length}.`;
+  }
+};
+
+const toggleJsonImport = () => {
+  showJsonImport.value = !showJsonImport.value;
 };
 
 // Publish Order
@@ -423,6 +604,15 @@ const generateRandomOrderAndPublish = () => {
           variant="outline"
           size="sm"
           class="h-7 text-xs"
+          @click="toggleJsonImport"
+        >
+          <Icon icon="material-symbols:data-object" class="w-3.5 h-3.5 mr-1" />
+          {{ showJsonImport ? "Hide JSON" : "Import JSON" }}
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          class="h-7 text-xs"
           @click="generateRandomOrderAndPublish"
         >
           <Icon icon="material-symbols:shuffle" class="w-3.5 h-3.5 mr-1" />
@@ -446,8 +636,110 @@ const generateRandomOrderAndPublish = () => {
       {{ error }}
     </div>
 
+    <div
+      v-if="jsonHint && !error"
+      class="text-sm text-muted-foreground bg-muted/50 p-2 rounded"
+    >
+      {{ jsonHint }}
+    </div>
+
+    <input
+      ref="jsonFileInputRef"
+      type="file"
+      accept=".json,.txt,application/json,text/plain"
+      class="hidden"
+      @change="onJsonFileSelected"
+    />
+
+    <div
+      v-if="showJsonImport"
+      class="border rounded-lg p-4 space-y-3 bg-muted/20"
+    >
+      <div class="flex items-center justify-between mb-1">
+        <h3 class="font-semibold text-sm">Import from JSON</h3>
+        <span class="text-xs text-muted-foreground">
+          Apply loads data into the form below
+        </span>
+      </div>
+
+      <div class="flex flex-wrap gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            class="h-7 text-xs"
+            @click="loadJsonFromFile"
+          >
+            <Icon icon="material-symbols:upload-file" class="w-3.5 h-3.5 mr-1" />
+            Load file
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            class="h-7 text-xs"
+            @click="validateOrderJson"
+          >
+            <Icon
+              icon="material-symbols:check-circle-outline"
+              class="w-3.5 h-3.5 mr-1"
+            />
+            Validate
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            class="h-7 text-xs"
+            @click="formatOrderJsonEditor"
+          >
+            <Icon icon="material-symbols:data-object" class="w-3.5 h-3.5 mr-1" />
+            Format
+          </Button>
+          <Button
+            size="sm"
+            class="h-7 text-xs"
+            @click="applyJsonToForm"
+          >
+            <Icon icon="material-symbols:input" class="w-3.5 h-3.5 mr-1" />
+            Apply to form
+          </Button>
+        </div>
+
+        <div v-if="jsonOrderCount > 1" class="flex items-center gap-2">
+          <Label class="text-xs shrink-0">Order in file</Label>
+          <Select
+            :model-value="String(selectedJsonOrderIndex)"
+            @update:model-value="(v) => selectJsonOrderByIndex(Number(v))"
+          >
+            <SelectTrigger class="h-8 text-xs flex-1">
+              <SelectValue placeholder="Select order" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem
+                v-for="i in jsonOrderCount"
+                :key="i - 1"
+                :value="String(i - 1)"
+              >
+                Order {{ i }} / {{ jsonOrderCount }}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div>
+          <Label class="text-xs text-muted-foreground">
+            Paste VDA5050 order JSON (e.g. from VdaOrders/*.txt). Multiple orders
+            separated by lines of = are supported.
+          </Label>
+          <Textarea
+            v-model="orderJsonText"
+            class="mt-2 font-mono text-xs min-h-[160px]"
+            spellcheck="false"
+            placeholder='{ "orderId": "PATH_ALPHA", "orderUpdateId": 0, "nodes": [...], "edges": [...] }'
+          />
+        </div>
+
+    </div>
+
     <div class="space-y-4">
-      <!-- Basic Information -->
       <div class="border rounded-lg p-4 space-y-3">
         <div
           class="flex items-center justify-between cursor-pointer"

--- a/src/utils/instant-action-json.ts
+++ b/src/utils/instant-action-json.ts
@@ -1,0 +1,196 @@
+import type { Action, InstantActions } from "vda-5050-lib";
+import type { AgvIdentity } from "@/utils/order-json";
+import { splitOrderJsonDocuments } from "@/utils/order-json";
+
+export type { AgvIdentity };
+
+export interface ParsedInstantActionsJson {
+  instantActions: InstantActions;
+  warnings: string[];
+}
+
+function normalizeActionsArray(obj: Record<string, unknown>): Action[] {
+  const raw = obj.instantActions ?? obj.actions;
+
+  if (!Array.isArray(raw)) {
+    throw new Error(
+      "InstantActions JSON must include a non-empty instantActions (or actions) array."
+    );
+  }
+
+  if (raw.length === 0) {
+    throw new Error(
+      "InstantActions must include at least one action in instantActions."
+    );
+  }
+
+  const actions: Action[] = [];
+
+  for (let i = 0; i < raw.length; i++) {
+    const item = raw[i];
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      throw new Error(`Action at index ${i} must be an object.`);
+    }
+
+    const action = item as Record<string, unknown>;
+    const actionId =
+      typeof action.actionId === "string" && action.actionId.trim()
+        ? action.actionId.trim()
+        : typeof action.actionId === "number"
+          ? String(action.actionId)
+          : "";
+
+    const actionType =
+      typeof action.actionType === "string" && action.actionType.trim()
+        ? action.actionType.trim()
+        : "";
+
+    if (!actionId) {
+      throw new Error(`Action at index ${i} is missing actionId.`);
+    }
+    if (!actionType) {
+      throw new Error(`Action at index ${i} is missing actionType.`);
+    }
+
+    actions.push({
+      ...(action as unknown as Action),
+      actionId,
+      actionType,
+    });
+  }
+
+  return actions;
+}
+
+export function splitInstantActionJsonDocuments(text: string): string[] {
+  return splitOrderJsonDocuments(text);
+}
+
+export function parseInstantActionsJson(
+  text: string,
+  agvId?: AgvIdentity
+): ParsedInstantActionsJson {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    throw new Error(`Invalid JSON: ${message}`);
+  }
+
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("InstantActions JSON must be an object.");
+  }
+
+  const obj = raw as Record<string, unknown>;
+  const warnings: string[] = [];
+
+  const manufacturer =
+    typeof obj.manufacturer === "string" && obj.manufacturer.trim()
+      ? obj.manufacturer.trim()
+      : agvId?.manufacturer;
+
+  const serialNumber =
+    typeof obj.serialNumber === "string" && obj.serialNumber.trim()
+      ? obj.serialNumber.trim()
+      : agvId?.serialNumber;
+
+  if (!manufacturer || !serialNumber) {
+    throw new Error(
+      "InstantActions JSON must include manufacturer and serialNumber (or select an AGV first)."
+    );
+  }
+
+  if (!obj.manufacturer && agvId) {
+    warnings.push(
+      `manufacturer defaulted to "${manufacturer}" from selected AGV.`
+    );
+  }
+  if (!obj.serialNumber && agvId) {
+    warnings.push(
+      `serialNumber defaulted to "${serialNumber}" from selected AGV.`
+    );
+  }
+
+  const headerId =
+    typeof obj.headerId === "number"
+      ? obj.headerId
+      : typeof obj.headerId === "string"
+        ? Number(obj.headerId)
+        : 1;
+
+  if (Number.isNaN(headerId)) {
+    throw new Error("headerId must be a number.");
+  }
+
+  const version =
+    typeof obj.version === "string" && obj.version.trim()
+      ? obj.version.trim()
+      : "2.0.0";
+
+  if (!obj.version) {
+    warnings.push(`version defaulted to "${version}".`);
+  }
+
+  const actions = normalizeActionsArray(obj);
+
+  if (obj.actions && !obj.instantActions) {
+    warnings.push('Used legacy "actions" field; form uses instantActions.');
+  }
+
+  const instantActions: InstantActions = {
+    headerId,
+    manufacturer,
+    serialNumber,
+    timestamp:
+      typeof obj.timestamp === "string" && obj.timestamp.trim()
+        ? obj.timestamp.trim()
+        : new Date().toISOString(),
+    version,
+    instantActions: actions,
+  };
+
+  return { instantActions, warnings };
+}
+
+export function parseInstantActionsJsonDocuments(
+  text: string,
+  agvId?: AgvIdentity
+): ParsedInstantActionsJson[] {
+  return splitInstantActionJsonDocuments(text).map((doc) =>
+    parseInstantActionsJson(doc, agvId)
+  );
+}
+
+export function formatInstantActionsJson(
+  instantActions: InstantActions,
+  pretty = true
+): string {
+  return JSON.stringify(instantActions, null, pretty ? 2 : 0);
+}
+
+export function instantActionsToFormState(
+  instantActions: InstantActions,
+  agvId: AgvIdentity
+): {
+  headerId: number;
+  manufacturer: string;
+  serialNumber: string;
+  timestamp: string;
+  version: string;
+  instantActions: Action[];
+} {
+  const actions =
+    instantActions.instantActions ??
+    (instantActions as InstantActions & { actions?: Action[] }).actions ??
+    [];
+
+  return {
+    headerId: instantActions.headerId ?? 1,
+    manufacturer: instantActions.manufacturer ?? agvId.manufacturer,
+    serialNumber: instantActions.serialNumber ?? agvId.serialNumber,
+    timestamp: instantActions.timestamp ?? new Date().toISOString(),
+    version: instantActions.version ?? "2.0.0",
+    instantActions: [...actions],
+  };
+}

--- a/src/utils/order-json.ts
+++ b/src/utils/order-json.ts
@@ -1,0 +1,180 @@
+import type { Order } from "vda-5050-lib";
+
+export interface AgvIdentity {
+  manufacturer: string;
+  serialNumber: string;
+}
+
+export interface ParsedOrderJson {
+  order: Order;
+  warnings: string[];
+}
+
+const REQUIRED_FIELDS = [
+  "orderId",
+  "orderUpdateId",
+  "nodes",
+  "edges",
+] as const;
+
+/** Split VdaOrders-style files (multiple JSON objects separated by lines of =). */
+export function splitOrderJsonDocuments(text: string): string[] {
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+
+  const parts = trimmed
+    .split(/\n={3,}\n/g)
+    .map((p) => p.trim())
+    .filter(Boolean);
+
+  if (parts.length > 0) return parts;
+
+  return [trimmed];
+}
+
+export function parseOrderJson(
+  text: string,
+  agvId?: AgvIdentity
+): ParsedOrderJson {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    throw new Error(`Invalid JSON: ${message}`);
+  }
+
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("Order JSON must be an object.");
+  }
+
+  const obj = raw as Record<string, unknown>;
+  const warnings: string[] = [];
+
+  for (const field of REQUIRED_FIELDS) {
+    if (obj[field] === undefined || obj[field] === null) {
+      throw new Error(`Missing required field: ${field}`);
+    }
+  }
+
+  if (!Array.isArray(obj.nodes) || obj.nodes.length === 0) {
+    throw new Error("Order must include a non-empty nodes array.");
+  }
+
+  if (!Array.isArray(obj.edges)) {
+    throw new Error("Order must include an edges array.");
+  }
+
+  const manufacturer =
+    typeof obj.manufacturer === "string" && obj.manufacturer.trim()
+      ? obj.manufacturer.trim()
+      : agvId?.manufacturer;
+
+  const serialNumber =
+    typeof obj.serialNumber === "string" && obj.serialNumber.trim()
+      ? obj.serialNumber.trim()
+      : agvId?.serialNumber;
+
+  if (!manufacturer || !serialNumber) {
+    throw new Error(
+      "Order JSON must include manufacturer and serialNumber (or select an AGV first)."
+    );
+  }
+
+  if (!obj.manufacturer && agvId) {
+    warnings.push(`manufacturer defaulted to "${manufacturer}" from selected AGV.`);
+  }
+  if (!obj.serialNumber && agvId) {
+    warnings.push(`serialNumber defaulted to "${serialNumber}" from selected AGV.`);
+  }
+
+  const headerId =
+    typeof obj.headerId === "number"
+      ? obj.headerId
+      : typeof obj.headerId === "string"
+        ? Number(obj.headerId)
+        : 1;
+
+  if (Number.isNaN(headerId)) {
+    throw new Error("headerId must be a number.");
+  }
+
+  const orderUpdateId =
+    typeof obj.orderUpdateId === "number"
+      ? obj.orderUpdateId
+      : Number(obj.orderUpdateId);
+
+  if (Number.isNaN(orderUpdateId)) {
+    throw new Error("orderUpdateId must be a number.");
+  }
+
+  const version =
+    typeof obj.version === "string" && obj.version.trim()
+      ? obj.version.trim()
+      : "2.0.0";
+
+  if (!obj.version) {
+    warnings.push(`version defaulted to "${version}".`);
+  }
+
+  const order: Order = {
+    headerId,
+    manufacturer,
+    serialNumber,
+    timestamp:
+      typeof obj.timestamp === "string" && obj.timestamp.trim()
+        ? obj.timestamp.trim()
+        : new Date().toISOString(),
+    version,
+    orderId: String(obj.orderId),
+    orderUpdateId,
+    nodes: obj.nodes as Order["nodes"],
+    edges: obj.edges as Order["edges"],
+  };
+
+  if (typeof obj.zoneSetId === "string" && obj.zoneSetId.trim()) {
+    order.zoneSetId = obj.zoneSetId.trim();
+  }
+
+  return { order, warnings };
+}
+
+export function parseOrderJsonDocuments(
+  text: string,
+  agvId?: AgvIdentity
+): ParsedOrderJson[] {
+  return splitOrderJsonDocuments(text).map((doc) => parseOrderJson(doc, agvId));
+}
+
+export function formatOrderJson(order: Order, pretty = true): string {
+  return JSON.stringify(order, null, pretty ? 2 : 0);
+}
+
+export function orderToFormState(
+  order: Order,
+  agvId: AgvIdentity
+): {
+  headerId: number;
+  manufacturer: string;
+  serialNumber: string;
+  timestamp: string;
+  version: string;
+  orderId: string;
+  orderUpdateId: number;
+  zoneSetId: string;
+  nodes: Order["nodes"];
+  edges: Order["edges"];
+} {
+  return {
+    headerId: order.headerId ?? 1,
+    manufacturer: order.manufacturer ?? agvId.manufacturer,
+    serialNumber: order.serialNumber ?? agvId.serialNumber,
+    timestamp: order.timestamp ?? new Date().toISOString(),
+    version: order.version ?? "2.0.0",
+    orderId: order.orderId,
+    orderUpdateId: order.orderUpdateId ?? 0,
+    zoneSetId: order.zoneSetId ?? "",
+    nodes: order.nodes ?? [],
+    edges: order.edges ?? [],
+  };
+}


### PR DESCRIPTION
# feat: Import VDA5050 orders from JSON in Create Order dialog

## Summary

Adds an optional **Import JSON** workflow to the existing **Create Order** form. Users can paste or load VDA5050 order JSON, validate it, optionally pick one of several orders from a multi-document file, apply it into the manual form for review/editing, and publish via the unchanged **Publish Order** button.


## Motivation

- **Faster testing**: Orders prepared for `vda5050-uagv-simulator` can be loaded directly into the visualizer.
- **Safer workflow**: JSON is validated before apply; users can edit fields in the form before publishing.
- **Multi-order files**: Supports files with several JSON objects separated by `====` lines (common in simulator sample order files).

## Changes

### New: `src/utils/order-json.ts`

Utility module for JSON order handling:

| Function | Purpose |
|----------|---------|
| `splitOrderJsonDocuments(text)` | Splits multi-order files on `\n===...\n` separators; single JSON returns one document |
| `parseOrderJson(text, agvId?)` | Parses and validates VDA5050 order shape; fills `manufacturer` / `serialNumber` from selected AGV when omitted |
| `parseOrderJsonDocuments(text, agvId?)` | Parses all documents in a file |
| `formatOrderJson(order)` | Pretty-prints order JSON |
| `orderToFormState(order, agvId)` | Maps `Order` → `OrderPublisher` form state |

**Validation rules:**

- Required: `orderId`, `orderUpdateId`, `nodes` (non-empty), `edges`
- `manufacturer` and `serialNumber` required in JSON **or** via selected AGV
- Defaults with warnings: `headerId` → `1`, `version` → `2.0.0`, `timestamp` → now (ISO)
- Clear errors for invalid JSON, missing fields, or non-numeric `orderUpdateId` / `headerId`

### Updated: `src/components/OrderPublisher.vue`

- **Import JSON** toggle button in the dialog header (collapsible panel; form always visible)
- Actions: **Load file** (`.json`, `.txt`), **Validate**, **Format**, **Apply to form**
- Order selector when multiple documents are detected
- Hints and toasts for validation warnings and successful apply
- On apply: expands **Order basic**, **Nodes**, and **Edges** sections for review
- **Publish Order** unchanged — still builds from form via `buildOrderFromForm()`

### Out of scope (exclude from this PR)

The following local changes are **not** part of this feature and should be reverted or committed separately:

- `.env` — `VITE_BASEPATH` local dev override
- `src/components/ConnectionModal.vue` — broker port validation tweak

## UX flow

```mermaid
flowchart LR
  A[Open Create Order] --> B[Import JSON]
  B --> C{Source}
  C -->|Paste| D[Editor]
  C -->|Load file| D
  D --> E[Validate]
  E --> F[Apply to form]
  F --> G[Review / edit form]
  G --> H[Publish Order]
```

## Operations

1. Create Order dialog with **Import JSON** panel expanded
2. Form populated after **Apply to form** (nodes/edges visible)
3. Toast after successful publish

## Test plan

### Manual test cases

| ID | Test case | Steps | Expected result |
|----|-----------|-------|-----------------|
| TC-01 | Open dialog without regression | Connect MQTT → select AGV → **Create Order** | Dialog opens; manual form works as before; no blank screen |
| TC-02 | Toggle JSON panel | Click **Import JSON** twice | Panel shows/hides; form remains usable |
| TC-03 | Validate minimal valid JSON | Paste single order with all required fields matching selected AGV (`manufacturer`, `serialNumber`) → **Validate** | Success toast; hint shows node/edge counts; no error banner |
| TC-04 | Apply to form | After TC-03 → **Apply to form** | `orderId`, nodes, edges populate form; basic/nodes/edges sections expanded; success toast |
| TC-05 | Edit then publish | Change `orderId` or add a node in form → **Publish Order** | Order published; AGV receives order on MQTT; map shows route if positions match layout |
| TC-06 | Load single-order file | **Load file** → `VdaOrders/001.txt` (first JSON only, or full file with one doc) → **Apply to form** | File loads; form matches file content |
| TC-07 | Multi-order file | Load full `001.txt` (contains `====` separators) | Selector shows **Order 1 / N**; switching order updates editor preview |
| TC-08 | Apply second order from file | Select **Order 2** → **Apply to form** | Form updates to second order’s `orderId`, nodes, edges |
| TC-09 | AGV identity fallback | Paste JSON **without** `manufacturer`/`serialNumber` while AGV `fleet/001` selected → **Validate** → **Apply** | Warnings about defaulted fields; form uses selected AGV identity |
| TC-10 | Missing identity error | Deselect / no AGV context; paste JSON without `manufacturer`/`serialNumber` → **Validate** | Error: must include manufacturer and serialNumber or select AGV |
| TC-11 | Invalid JSON syntax | Paste `{ broken` → **Validate** | Error: `Invalid JSON: ...` |
| TC-12 | Missing required field | Paste object without `nodes` → **Validate** | Error: `Missing required field: nodes` |
| TC-13 | Empty nodes array | Paste order with `"nodes": []` → **Validate** | Error: non-empty nodes required |
| TC-14 | Format JSON | Paste minified JSON → **Format** | Editor shows pretty-printed JSON; invalid input shows error |
| TC-15 | Publish without apply | Paste valid JSON but do **not** click **Apply to form** → **Publish Order** | Publishes **form** content (not editor-only JSON); confirms two-step workflow |
| TC-16 | Existing order update flow | Open **Create Order** when AGV already has an order | Existing order still pre-fills form; JSON import does not break increment of `headerId` / `orderUpdateId` |
| TC-17 | Random order still works | **Generate Random** without using JSON | Unchanged behavior |

### Integration test cases (with simulator)

| ID | Test case | Steps | Expected result |
|----|-----------|-------|-----------------|
| IT-01 | End-to-end drive | Pitaya broker → simulator TCP `1883` → visualizer WS `9001`, interface `uagv` → import `001.txt` order for `serialNumber` `001` → align `mapId` / first node with AGV pose → **Publish** | Vehicle moves along path on map |
| IT-02 | Wrong serial | Import order for `serialNumber: "999"` while AGV `001` selected → publish without fixing serial | Simulator ignores or no motion (document expected behavior) |
| IT-03 | Interface alignment | Broker interface `uagv`; order uses `manufacturer` matching topic (`fleet` segment) | State/order topics consistent |

### Sample JSON snippets (unit-style checks)

Use these in the editor with **Validate** / **Apply** (adjust `serialNumber` to your AGV).

**Valid minimal order (with AGV selected, identity omitted):**

```json
{
  "orderId": "test-json-import",
  "orderUpdateId": 0,
  "nodes": [
    {
      "nodeId": "N1",
      "sequenceId": 0,
      "released": true,
      "nodePosition": { "x": 0, "y": 0, "mapId": "Warehouse_A" }
    }
  ],
  "edges": []
}
```

**Invalid — should fail validation:**

```json
{
  "orderId": "no-nodes",
  "orderUpdateId": 0,
  "nodes": [],
  "edges": []
}
```

**Multi-document file format:**

```text
{ "orderId": "first", "orderUpdateId": 0, "manufacturer": "fleet", "serialNumber": "001", "nodes": [...], "edges": [] }

====================================

{ "orderId": "second", "orderUpdateId": 0, "manufacturer": "fleet", "serialNumber": "001", "nodes": [...], "edges": [] }
```

### Regression checklist

- [ ] Create Order dialog renders on first open (no Vue/template errors)
- [ ] Manual add node / edge / action still works
- [ ] **Publish Order** and **Generate Random** unchanged
- [ ] Close dialog and reopen — state resets appropriately

## Future improvements (not in this PR)

- Unit tests for `order-json.ts` (Vitest)
- Export current form to JSON
- Drag-and-drop file onto JSON panel
- Schema validation against official VDA5050 JSON Schema